### PR TITLE
Exclude images from the crate package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ readme = "README.md"
 keywords = ["image", "size"]
 categories = ["multimedia", "multimedia::images"]
 license = "MIT"
+exclude = ["test/*"]
 
 [dependencies]


### PR DESCRIPTION
This decreases `*.crate` file (the one that cargo uses to build this crate) size from 570KiB to 4.2KiB.