### PR TITLE
Handle HDR files orientations

### DIFF
--- a/src/formats/farbfeld.rs
+++ b/src/formats/farbfeld.rs
@@ -8,7 +8,7 @@ use crate::{
 pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
     reader.seek(SeekFrom::Start(8))?;
 
-    Ok(ImageSize { 
+    Ok(ImageSize {
         width: read_u32(reader, &Endian::Big)? as usize,
         height: read_u32(reader, &Endian::Big)? as usize,
     })

--- a/src/formats/hdr.rs
+++ b/src/formats/hdr.rs
@@ -1,9 +1,6 @@
 use std::io::{self, BufRead, Seek, SeekFrom};
 
-use crate::{
-    util::read_line_capped,
-    ImageResult, ImageSize
-};
+use crate::{util::read_line_capped, ImageResult, ImageSize};
 
 pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
     reader.seek(SeekFrom::Start(0))?;
@@ -29,7 +26,7 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
         }
 
         // HDR image dimensions can be stored in 8 different ways based on orientation
-        // Using EXIF orientation as a reference: 
+        // Using EXIF orientation as a reference:
         // https://web.archive.org/web/20220924095433/https://sirv.sirv.com/website/exif-orientation-values.jpg
         //
         // -Y N +X M => Standard orientation (EXIF 1)
@@ -63,7 +60,7 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
             let height_parsed = dimensions[1].parse::<usize>().ok();
             let width_parsed = dimensions[3].parse::<usize>().ok();
 
-            if let(Some(width), Some(height)) = (width_parsed, height_parsed) {
+            if let (Some(width), Some(height)) = (width_parsed, height_parsed) {
                 return Ok(ImageSize { width, height });
             }
 

--- a/src/formats/hdr.rs
+++ b/src/formats/hdr.rs
@@ -23,6 +23,19 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
             break;
         }
 
+        // HDR image dimensions can be stored in 8 different ways based on orientation
+        // Using EXIF orientation as a reference: 
+        // https://web.archive.org/web/20220924095433/https://sirv.sirv.com/website/exif-orientation-values.jpg
+        //
+        // -Y N +X M => Standard orientation (EXIF 1)
+        // -Y N -X M => Flipped horizontally (EXIF 2)
+        // +Y N -X M => Flipped vertically and horizontally (EXIF 3)
+        // +Y N +X M => Flipped vertically (EXIF 4)
+        // +X M -Y N => Rotate 90 CCW and flip vertically (EXIF 5)
+        // -X M -Y N => Rotate 90 CCW (EXIF 6)
+        // -X M +Y N => Rotate 90 CW and flip vertically (EXIF 7)
+        // +X M +Y N => Rotate 90 CW (EXIF 8)
+
         // Extract width and height information
         if line.trim().is_empty() || !line.starts_with("-Y") {
             continue;

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -100,6 +100,6 @@ pub fn image_type(header: &[u8]) -> ImageResult<ImageType> {
     if farbfeld::matches(header) {
         return Ok(ImageType::Farbfeld);
     }
-    
+
     Err(ImageError::NotSupported)
 }


### PR DESCRIPTION
While trying to figure out a better way to support HDR without relying on `read_line`, I came across the [HDR spec](https://radsite.lbl.gov/radiance/refer/filefmts.pdf). In the Resolution String section (page 31) I found out that `-Y` does not just denote the start of a standard width/height resolution. Resolutions can either start with +/- X/Y, which means the original implementation only supports 2/8 valid HDR resolution strings.

Before release I plan on adding support for these orientations. Not sure where I can find HDR test files for this though.

Supported orientations based on [ExifTool](https://exiftool.org/TagNames/EXIF.html) notation:
- [x] Horizontal (normal)
- [x] Mirror horizontal
- [x] Rotate 180
- [x] Mirror vertical
- [x] Mirror horizontal and rotate 270 CW
- [x] Rotate 90 CW
- [x] Mirror horizontal and rotate 90 CW
- [x] Rotate 270 CW