### PR TITLE
Handle EXR long names flag

### DIFF
--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -10,7 +10,7 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
     // If long names flag is set then max attribute name and type name is 255, otherwise it's only 31
     let flags = read_u32(reader, &Endian::Little)?;
-    let long_names = flags & 0x400 == 1;
+    let long_names = flags & 0x400 != 0;
     let max_name_size = if long_names { 255 } else { 31 };
 
     // Read header attributes until we find the dataWindow attribute

--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -6,16 +6,21 @@ use crate::{
 };
 
 pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
-    reader.seek(SeekFrom::Start(8))?;
+    reader.seek(SeekFrom::Start(4))?;
+
+    // If long names flag is set then max attribute name and type name is 255, otherwise it's only 31
+    let flags = read_u32(reader, &Endian::Little)?;
+    let long_names = flags & 0x400 == 1;
+    let max_name_size = if long_names { 255 } else { 31 };
 
     // Read header attributes until we find the dataWindow attribute
     loop {
-        let attr_name = read_null_terminated_string(reader, 255)?;
+        let attr_name = read_null_terminated_string(reader, max_name_size)?;
         if attr_name.is_empty() {
             break; // End of the header
         }
 
-        let attr_type = read_null_terminated_string(reader, 255)?;
+        let attr_type = read_null_terminated_string(reader, max_name_size)?;
 
         // Skip attr_size
         let attr_size = read_u32(reader, &Endian::Little)?;


### PR DESCRIPTION
According to the [OpenEXR docs](https://openexr.com/en/latest/OpenEXRFileLayout.html#components-one-and-two-magic-number-and-version-field), the long name bit flag indicates whether or not the maximum attribute name is 255 characters or 31 characters. This uses that flag to avoid reading more data than is required for the file.